### PR TITLE
feat: wrap root with `ChakraProvider`

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,7 +1,12 @@
-import '../styles/globals.css'
+import { ChakraProvider } from "@chakra-ui/react";
+import "../styles/globals.css";
 
 function MyApp({ Component, pageProps }) {
-  return <Component {...pageProps} />
+  return (
+    <ChakraProvider resetCSS>
+      <Component {...pageProps} />
+    </ChakraProvider>
+  );
 }
 
-export default MyApp
+export default MyApp;


### PR DESCRIPTION
For Chakra UI to work correctly, we need to set up the `ChakraProvider` at the root of your application.